### PR TITLE
feature: Add PHP Security Checker action to check dependencies

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,34 @@
+on:
+  pull_request:
+    branches: [dev, master]
+name: Security
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+
+    - uses: actions/cache@v2
+      id: cache-db
+      with:
+        path: ~/.symfony/cache
+        key: db
+
+    - name: Run dependencies security checker
+      id: dependencies
+      working-directory: ./
+      run: |
+        docker run --rm -v $(pwd):$(pwd) -w $(pwd) symfonycorp/cli check:security 2>&1 | tee security.report
+        message=$(awk '/Symfony Security Check Report/, 0' security.report)
+        message="${message//$'\n'/<br />}"
+        echo "::set-output name=message::$message"
+
+    - name: Report dependencies security vulnerabilities
+      if: always()
+      uses: phulsechinmay/rewritable-pr-comment@v0.2.1
+      with:
+        message: '<h2>:closed_lock_with_key: Dependencies security vulnerabilities</h2><pre>${{ steps.dependencies.outputs.message }}</pre>'
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COMMENT_IDENTIFIER: 'php-security-checker-action'


### PR DESCRIPTION
Add non-blocking Github Action to check PHP dependencies security vulnerabilities using Symfony Security Check. 
More info in https://symfony.com/blog/the-php-security-checker-as-a-docker-image 
 
You can see the result of the action just below 👇 
 
Linked to https://github.com/inextensodigital/bridge.infra/issues/485
